### PR TITLE
Grant platform apps access to /mnt/media_rw with sdcard_posix label

### DIFF
--- a/sepolicy/app.te
+++ b/sepolicy/app.te
@@ -1,3 +1,8 @@
+# Access OBBs (sdcard_posix) mounted by vold
+# File write access allowed for FDs returned through Storage Access Framework
+allow appdomain sdcard_posix:dir r_dir_perms;
+allow appdomain sdcard_posix:file rw_file_perms;
+
 # Themed resources (i.e. composed icons)
 allow appdomain theme_data_file:dir r_dir_perms;
 allow appdomain theme_data_file:file r_file_perms;

--- a/sepolicy/platform_app.te
+++ b/sepolicy/platform_app.te
@@ -1,0 +1,4 @@
+# Direct access to vold-mounted storage under /mnt/media_rw
+# This is a performance optimization that allows platform apps to bypass the FUSE layer
+allow platform_app sdcard_posix:dir create_dir_perms;
+allow platform_app sdcard_posix:file create_file_perms;


### PR DESCRIPTION
Also allow apps to read the contents of mounted OBBs.

See AOSP Change-Id: I66df236eade3ca25a10749dd43d173ff4628cfad
and Change-Id: I49b722b24c1c7d9ab084ebee7c1e349d8d660ffa

Change-Id: I757a2a8831c69d41c0496025a39eaf79ceb0e65f